### PR TITLE
Feature/sim 1547 incorporate simulation of historical

### DIFF
--- a/examples/example_parser.py
+++ b/examples/example_parser.py
@@ -17,9 +17,9 @@ PARSER.add_argument("-oc", "--opsim_constraint",
         help="constraint for opsim query")
 PARSER.add_argument("-cc", "--catsim_constraint", 
         default="rmag between 20 and 23.5", help="constraint for catsim query")
-PARSER.add_argument("-ca", "--catsim_catalog", 
-        choices=["variable_stars", "vanilla_stars", "DIA_sources", "DIA_objects"], 
-        default="variable_stars", help="name of catsim catalog")
+#PARSER.add_argument("-ca", "--catsim_catalog", 
+#        choices=["variable_stars", "vanilla_stars", "DIA_sources", "DIA_objects"], 
+#        default="variable_stars", help="name of catsim catalog")
 PARSER.add_argument("-r", "--radius", type=float, default="0.05", 
         help="cone search radius")
 PARSER.add_argument("-p", "--port", type=int, 
@@ -31,6 +31,9 @@ PARSER.add_argument("-ip", "--ipaddress",
         default='147.91.240.26')
 PARSER.add_argument("--no_header",
         help="don't generate hex header for VOEvents", 
+        action="store_false", default=True)
+PARSER.add_argument("--no_history",
+        help="emit only current DiaSource", 
         action="store_false", default=True)
 ARGS = PARSER.parse_args()
 
@@ -61,5 +64,5 @@ if __name__ == "__main__":
     if (validate_ip(ARGS.ipaddress, ARGS.protocol)):
         sys.exit(alertsim.main(ARGS.opsim_table, ARGS.catsim_table, 
                 ARGS.opsim_constraint, ARGS.catsim_constraint, 
-                ARGS.catsim_catalog, ARGS.radius, ARGS.protocol, 
-                ARGS.ipaddress, ARGS.port, ARGS.no_header))
+                ARGS.radius, ARGS.protocol, ARGS.ipaddress, 
+                ARGS.port, ARGS.no_header, ARGS.no_history))

--- a/python/lsst/sims/sims_alertsim/alertsim/alertsim_main.py
+++ b/python/lsst/sims/sims_alertsim/alertsim/alertsim_main.py
@@ -1,33 +1,67 @@
 """ Main module """
 
 import subprocess
+import sys
 import time
-from dataModel import DataMetadata, CelestialObject
-from generateVOEvent import VOEventGenerator
+import functools
 import catsim_utils, opsim_utils
+#import threading
+#import itertools
+from copy import deepcopy
+from lsst.sims.sims_alertsim.alertsim.dataModel import DataMetadata, CelestialObject
+from lsst.sims.sims_alertsim.alertsim.generateVOEvent import VOEventGenerator
 from lsst.sims.sims_alertsim.broadcast import *
 from lsst.sims.sims_alertsim.catalogs import *
 
+BANDNAMES = ['u', 'g', 'r', 'i', 'z', 'y']
+STACK_VERSION = 10
+
 def main(opsim_table, catsim_table, opsim_constraint, 
-         catsim_constraint, catalog, radius, protocol, ipaddr, port, header):
+         catsim_constraint, radius, protocol, ipaddr, port, header, history):
 
     """ Takes input args from cmd line parser or other,  
         query opsim, catsim, generate 
         and broadcast VOEvents 
     """
 
-    print "Sims version: %s" % _get_sims_version() 
+    print "Sims version: %s" % get_sims_version() 
 
     sender = get_sender(protocol, ipaddr, port, header)
     
-    observations = opsim_utils.opsim_query(stack_version=10, 
-            objid=opsim_table, constraint=opsim_constraint)
-    for obs in observations:
-        obs_data, obs_metadata = catsim_utils.catsim_query(stack_version=10, 
+    print "fetching opsim results..."
+    
+    # keeping this for now, will try to build a thread-based spinner 
+    # for db queries as they can last quite a bit
+    """
+    obs_all = []
+    t1 = threading.Thread(target = thread_wrapper, 
+            args = (opsim_utils.opsim_query, 
+                (stack_version=STACK_VERSION, objid=opsim_table, 
+                    radius=radius, constraint=opsim_constraint), obs_all))
+    
+    while t1.is_alive():
+        sys.stdout.write(spinner.next())  # write the next character
+        sys.stdout.flush()                # flush stdout buffer (actual character display)
+        sys.stdout.write('\b')            # erase the last written char
+        t1.join(0.2)
+    """
+
+    """ matrix of all observations per field up to current mjd """
+    obs_all = opsim_utils.opsim_query(stack_version=10, 
+            objid=opsim_table, radius=radius, constraint=opsim_constraint)
+
+    print "opsim result fetched and transformed to ObservationMetaData objects"
+
+    for obs_per_field in obs_all:
+
+        """ current observation - largest mjd from a sorted list  """
+        obs_metadata = obs_per_field[0]
+        
+        obs_data = catsim_utils.catsim_query(stack_version=10, 
                 objid=catsim_table, constraint=catsim_constraint, 
-                catalog=catalog, radius=radius, opsim_metadata=obs)
-        #print vars(obs_metadata)
-        iter_and_send(sender, obs_data, obs_metadata)
+                obs_metadata=obs_metadata)
+
+        iter_and_send(sender, obs_data, obs_metadata, obs_per_field, history)
     
     sender.close()
 
@@ -35,39 +69,92 @@ def get_sender(protocol, ipaddr, port, header):
     """ Instantiate proper child class for the protocol """
     return vars(broadcast)[protocol](ipaddr, port, header)
 
-def iter_and_send(sender, obs_data, obs_metadata):
+def iter_and_send(sender, obs_data, obs_metadata, observations_field, history):
+
     """ Iterate over catalog and generate XML """
-    count = 0
+
+    event_count = 0
     sending_times = []
 
-    for (diasource_line, diaobject_line) in zip(obs_data[0].iter_catalog(), obs_data[1].iter_catalog()):
+    for line in obs_data.iter_catalog():
+
+        # current + historical exposures
+        cel_objects = []
+
         data_metadata = []
-        for (val, ucd, unit) in zip(diasource_line, 
-                obs_data[0].get_ucds(), obs_data[0].get_units()):
+            
+        # append metadata to each attribute
+        for (val, ucd, unit) in zip(line, obs_data.get_ucds(), 
+                obs_data.get_units()):
             data_metadata.append(DataMetadata(val, ucd, unit))
-        diasource = CelestialObject(obs_data[0].iter_column_names(), 
+
+        # current exposure with all mags and deltas. 
+        # will need it for calculating historical variability in 
+        # different bands.
+
+        cel_obj_all_mags = CelestialObject(obs_data.iter_column_names(), 
                 data_metadata)
-        for (val, ucd, unit) in zip(diaobject_line, 
-                obs_data[1].get_ucds(), obs_data[1].get_units()):
-            data_metadata.append(DataMetadata(val, ucd, unit))
-        diaobject = CelestialObject(obs_data[1].iter_column_names(), 
-                data_metadata)
-        gen = VOEventGenerator(eventid = count)
-        xml = gen.generateFromObjects(diasource, diaobject, obs_metadata)
+        cel_obj = deepcopy(cel_obj_all_mags)
+        
+        # reduce to a single band
+        _remove_band_attrs(cel_obj, obs_metadata.bandpass)
+        cel_objects.append(cel_obj)
+
+        # historical exposures can be turned off
+        if history:
+            
+            base_mags = {}
+            for band in BANDNAMES:
+                # substract deltas from mags to get base for historical mags
+                mag_attr = getattr(cel_obj_all_mags, 'lsst_'+band)
+                delta_mag_attr = getattr(cel_obj_all_mags, 'delta_lsst_'+band)
+                # other way would be to calculate historical mags 
+                # via PhotometryStars. 
+                base_mags[band] = mag_attr.value + delta_mag_attr.value
+
+            for historical_metadata in observations_field:
+                vs = VariabilityDummy(historical_metadata)
+
+                # can we get filter-parametrized variabilities 
+                # from VariabilityMixin please? 
+                hist_delta_mags = vs.applyVariability(cel_obj_all_mags.varParamStr.value)
+                hist_cel_obj = deepcopy(cel_obj_all_mags)
+
+                # not optimal but most flexible for now
+                for band in BANDNAMES:
+                    hist_mag = base_mags[band] + hist_delta_mags[band] 
+                    hist_delta_mag = hist_delta_mags[band]
+                    _rsetattr(hist_cel_obj, 'lsst_'+band+'.value', hist_mag)
+                    _rsetattr(hist_cel_obj, 'delta_lsst_'+band+'.value', 
+                            hist_delta_mag)
+                
+                _remove_band_attrs(hist_cel_obj, historical_metadata.bandpass)
+                cel_objects.append(hist_cel_obj)
+
+
+        # generate and send
+        gen = VOEventGenerator(eventid = event_count)
+        xml = gen.generateFromObjects(cel_objects, obs_metadata)
+        #print xml
         sender.send(xml)
-        count = count + 1
+        event_count += 1
         sending_times.append(time.time())
 
-    sending_diff = sending_times[-1] - sending_times[0]
-    print "Number of events from this visit : %d. Time from first to last " \
-       "event %f or %f per event" % (count, sending_diff, sending_diff/count)
+    # add exception for index out of range
+    try:
+        sending_diff = sending_times[-1] - sending_times[0]
+        print "Number of events from this visit : %d. Time from first to last " \
+            "event %f or %f per event" % (event_count, sending_diff, 
+                    sending_diff/event_count)
+    except IndexError:
+        print "No events in this visit"
 
-def _get_stack_version(fine_grain=True):
+def get_stack_version(fine_grain=True):
     """ ask eups for stack version, return in 2 flavors """ 
     # shell eups command to get version like 8.0.0.2
     # how to get version without eups?
 
-    # now obsolete for time being
+    # obsolete for time being
     stack_version = subprocess.check_output("eups list lsst --version " \
             "--tag current", shell=True)
     if fine_grain:
@@ -75,33 +162,36 @@ def _get_stack_version(fine_grain=True):
     else:
         return int(stack_version.split('.')[0])
 
-def _get_sims_version():
+def get_sims_version():
+    """ current sims version """
     return subprocess.check_output("eups list lsst_sims --version " \
             "--tag current", shell=True)
-        gen = VOEventGenerator(eventid = count)
-        xml = gen.generateFromObjects(celestial_object, obs_metadata)
-        sender.send(xml)
-        count = count + 1
-        sending_times.append(time.time())
 
-    sending_diff = sending_times[-1] - sending_times[0]
-    print "Number of events from this visit : %d. Time from first to last " \
-       "event %f or %f per event" % (count, sending_diff, sending_diff/count)
+def _remove_band_attrs(obj, bandname):
+    """ reduce object dictionary """
+    # this may not be the safest way and needs to be revised
+    for key in obj.__dict__.keys():
+        if ('lsst' in key) and not (key.endswith(bandname)):
+            obj.__dict__.pop(key)
 
-def _get_stack_version(fine_grain=True):
-    """ ask eups for stack version, return in 2 flavors """ 
-    # shell eups command to get version like 8.0.0.2
-    # how to get version without eups?
+"""
+def _rename_band_attr(obj, bandname):
+        for key in obj.__dict__:
+            if 'lsst' in key:
+                new_key = key[:-1] + bandname
+                obj.__dict__[new_key] = obj.__dict__.pop(old_name)
+"""
 
-    # now obsolete for time being
+def _rsetattr(obj, attr, val):
+    """ fix setattr lack of dot notation support """
+    pre, _, post = attr.rpartition('.')
+    return setattr(functools.reduce(getattr, 
+        [obj]+pre.split('.')) if pre else obj, post, val)
 
-    stack_version = subprocess.check_output("eups list lsst --version " \
-            "--tag current", shell=True)
-    if fine_grain:
-        return stack_version
-    else:
-        return int(stack_version.split('.')[0])
+"""
+def thread_wrapper(func, args, res):
+    res.append(func(*args))
 
-def _get_sims_version():
-    return subprocess.check_output("eups list lsst_sims --version " \
-            "--tag current", shell=True)
+def spinner():
+    return itertools.cycle(['-', '/', '|', '\\'])
+"""

--- a/python/lsst/sims/sims_alertsim/alertsim/catsim_utils.py
+++ b/python/lsst/sims/sims_alertsim/alertsim/catsim_utils.py
@@ -1,8 +1,5 @@
 """ Query catsim """
 
-from math import pi
-#from lsst.sims.catUtils.baseCatalogModels import *
-
 def catsim_query(stack_version, **kwargs):
 
     """ Determine stack version """
@@ -13,47 +10,37 @@ def catsim_query(stack_version, **kwargs):
         return catsim_query_stack10(**kwargs)
 
 
-def catsim_query_stack8(objid, constraint, catalog, radius, opsim_metadata):
+def catsim_query_stack8(objid, constraint, obs_metadata):
 
     """ Query catsim and make a catalog """
 
-    from lsst.sims.catalogs.generation.db import DBObject, ObservationMetaData
+    from lsst.sims.catalogs.generation.db import DBObject
 
-    obs_metadata = ObservationMetaData(circ_bounds=dict
-            (ra=opsim_metadata[1]*180/pi, 
-                dec=opsim_metadata[2]*180/pi, 
-                radius=radius),
-            mjd=opsim_metadata[5])
     dbobj = DBObject.from_objid(objid)
     
-    obs_data = dbobj.getCatalog(catalog, 
+    obs_data = dbobj.getCatalog('variable_stars', 
             obs_metadata=obs_metadata, 
             constraint=constraint)
+
 #    filename = 'test_reference.dat'
 #    t.write_catalog(filename, chunk_size=10)
-    return obs_data, obs_metadata
+    return obs_data
 
 
-def catsim_query_stack10 (objid, constraint, catalog, radius, opsim_metadata):
+def catsim_query_stack10 (objid, constraint, obs_metadata):
     
     """ Query catsim and make a catalog """
 
     from lsst.sims.catalogs.generation.db import CatalogDBObject
-    from lsst.sims.utils import  ObservationMetaData
+    from lsst.sims.sims_alertsim.catalogs import *
     
-    obs_metadata = ObservationMetaData(boundType='circle', 
-            pointingRA=opsim_metadata[1]*180/pi, 
-            pointingDec=opsim_metadata[2]*180/pi, 
-            boundLength=radius, mjd=opsim_metadata[5], 
-            bandpassName=opsim_metadata[4])
     dbobj = CatalogDBObject.from_objid(objid)
     #dbobj.show_db_columns()    
-    obs_data = [dbobj.getCatalog(catalog, 
-            obs_metadata=obs_metadata, 
-            constraint=constraint), 
-            dbobj.getCatalog("DIAObjects",
-            obs_metadata=obs_metadata, 
-            constraint=constraint), 
+
+    obs_data = dbobj.getCatalog('variable_stars', 
+            obs_metadata=obs_metadata, constraint=constraint)
+            #column_outputs=VariableStars.get_column_outputs(obs_metadata.bandpass)) 
+
 #    filename = 'test_reference.dat'
 #    t.write_catalog(filename, chunk_size=10)
-    return obs_data, obs_metadata
+    return obs_data

--- a/python/lsst/sims/sims_alertsim/alertsim/catsim_utils.py
+++ b/python/lsst/sims/sims_alertsim/alertsim/catsim_utils.py
@@ -48,9 +48,12 @@ def catsim_query_stack10 (objid, constraint, catalog, radius, opsim_metadata):
             bandpassName=opsim_metadata[4])
     dbobj = CatalogDBObject.from_objid(objid)
     #dbobj.show_db_columns()    
-    obs_data = dbobj.getCatalog(catalog, 
+    obs_data = [dbobj.getCatalog(catalog, 
             obs_metadata=obs_metadata, 
-            constraint=constraint)
+            constraint=constraint), 
+            dbobj.getCatalog("DIAObjects",
+            obs_metadata=obs_metadata, 
+            constraint=constraint), 
 #    filename = 'test_reference.dat'
 #    t.write_catalog(filename, chunk_size=10)
     return obs_data, obs_metadata

--- a/python/lsst/sims/sims_alertsim/alertsim/generateVOEvent.py
+++ b/python/lsst/sims/sims_alertsim/alertsim/generateVOEvent.py
@@ -41,9 +41,10 @@ class VOEventGenerator:
         self.voevent.set_Citations(c)
 
 
-    def generateFromObjects(self, diaSourceData, diaObjectData, obsMetaData):
+    #def generateFromObjects(self, diaSourceData, diaObjectData, obsMetaData):
+    def generateFromObjects(self, diaSourcesData, obsMetaData):
 
-        for key, data_tuple in diaSourceData.__dict__.items():
+        for key, data_tuple in diaSourcesData[0].__dict__.items():
             if data_tuple.ucd == 'pos.eq.ra':
                 self.ra = data_tuple.value
             elif data_tuple.ucd == 'pos.eq.dec':
@@ -52,20 +53,22 @@ class VOEventGenerator:
         ############ What ############################
         w = What()
 #        
-        g = Group(type_="DIASource", name="DIASource")
-        for key, val in diaSourceData.__dict__.items():
-            if not key.startswith("__"):
-                p = Param(name=key, ucd=val.ucd, value=val.value, unit = val.unit)
-                g.add_Param(p)
-        w.add_Group(g)
+        for diaSourceData in diaSourcesData:
+            g = Group(type_="DIASource", name="DIASource")
+            for key, val in diaSourceData.__dict__.items():
+                if not key.startswith("__"):
+                    p = Param(name=key, ucd=val.ucd, value=val.value, unit = val.unit)
+                    g.add_Param(p)
+            w.add_Group(g)
         
+        """
         g = Group(type_="DIAObject", name="DIAObject")
         for key, val in diaObjectData.__dict__.items():
             if not key.startswith("__"):
                 p = Param(name=key, ucd=val.ucd, value=val.value, unit = val.unit)
                 g.add_Param(p)
         w.add_Group(g)
-#        
+#       """ 
         self.voevent.set_What(w)
 
         ############ Wherewhen ############################

--- a/python/lsst/sims/sims_alertsim/alertsim/generateVOEvent.py
+++ b/python/lsst/sims/sims_alertsim/alertsim/generateVOEvent.py
@@ -41,9 +41,9 @@ class VOEventGenerator:
         self.voevent.set_Citations(c)
 
 
-    def generateFromObjects(self, objData, obsMetaData):
+    def generateFromObjects(self, diaSourceData, diaObjectData, obsMetaData):
 
-        for key, data_tuple in objData.__dict__.items():
+        for key, data_tuple in diaSourceData.__dict__.items():
             if data_tuple.ucd == 'pos.eq.ra':
                 self.ra = data_tuple.value
             elif data_tuple.ucd == 'pos.eq.dec':
@@ -52,27 +52,19 @@ class VOEventGenerator:
         ############ What ############################
         w = What()
 #        
-        g = Group(type_="Magnitudes", name="Magnitudes")
-        for key, val in objData.__dict__.items():
+        g = Group(type_="DIASource", name="DIASource")
+        for key, val in diaSourceData.__dict__.items():
             if not key.startswith("__"):
-                if val.ucd == 'phot.mag':
-                    p = Param(name=key, ucd=val.ucd, value=val.value, unit = val.unit)
-#                    p.set_Description(["magnitude"])
-#                    p=Param()
-#                    p.set_name(key)
-#                    p.set_value(float(val.value))
-#                    p.set_ucd(val.ucd)
-#                    p.set_unit(val.unit)
-#                    p.set_dataType("float")
-                    g.add_Param(p)
-#                    w.add_Param(p)
+                p = Param(name=key, ucd=val.ucd, value=val.value, unit = val.unit)
+                g.add_Param(p)
         w.add_Group(g)
         
-        for key, val in objData.__dict__.items():
+        g = Group(type_="DIAObject", name="DIAObject")
+        for key, val in diaObjectData.__dict__.items():
             if not key.startswith("__"):
-                if val.ucd != 'phot.mag':
-                    p = Param(name=key, ucd=val.ucd, value=val.value, unit = val.unit)
-                    w.add_Param(p)
+                p = Param(name=key, ucd=val.ucd, value=val.value, unit = val.unit)
+                g.add_Param(p)
+        w.add_Group(g)
 #        
         self.voevent.set_What(w)
 

--- a/python/lsst/sims/sims_alertsim/broadcast/broadcast.py
+++ b/python/lsst/sims/sims_alertsim/broadcast/broadcast.py
@@ -2,6 +2,7 @@ import socket
 import struct
 import sys
 import errno
+import zlib
 
 class Broadcast(object):
 
@@ -22,8 +23,8 @@ class Broadcast(object):
         print >>sys.stderr, 'closing socket'
         sys.exit(1)
     
-    @staticmethod
-    def _add_voevent_header(message):
+    #@staticmethod
+    def _add_voevent_header(self, message):
         header = '%08x' % (len(message))
         return header.decode('hex') + message
 
@@ -44,6 +45,7 @@ class TcpIp(Broadcast):
             self.close()
 
     def send(self, message):
+        #message = zlib.compress(message, 9)
         try:
             self._send_and_receive(message)
         except socket.error as e:

--- a/python/lsst/sims/sims_alertsim/catalogs/catalogExamples.py
+++ b/python/lsst/sims/sims_alertsim/catalogs/catalogExamples.py
@@ -19,43 +19,140 @@ def rbi():
 
 class VariableStars(InstanceCatalog,PhotometryStars,VariabilityStars):
 
-    """
-    def __init__(self, band):
-        column_outputs += [band, band + '_var']
-    """
+    """ Class for describing variable stars output """ 
     
     catalog_type = 'variable_stars'
     
-    column_outputs = ['id','raJ2000','decJ2000',
-                      'lsst_u','lsst_g','lsst_r','lsst_i','lsst_z','lsst_y',
-                      'delta_lsst_u','delta_lsst_g','delta_lsst_r',
-                      'delta_lsst_i','delta_lsst_z', 'delta_lsst_y', 
-                      'varParamStr']
-    """
-    column_outputs = ['id', 'raJ2000', 'decJ2000',
-                      'lsst_u', 'lsst_g', 'lsst_r', 'lsst_i', 'lsst_z', 
-                      'lsst_y', 'lsst_u_var', 'lsst_g_var', 'lsst_r_var', 
-                      'lsst_i_var', 'lsst_z_var', 'lsst_y_var']
-    """
-    def get_ucds(self):
-        return ['meta.id', 'pos.eq.ra', 'pos.eq.dec', 
-                'phot.mag', 'phot.mag', 'phot.mag', 'phot.mag',
-                'phot.mag', 'phot.mag', 'phot.mag', 'phot.mag',
-                'phot.mag', 'phot.mag', 'phot.mag', 'phot.mag', 'src.var' ]
+    column_outputs = ['id', 'raJ2000', 'decJ2000', 
+            'lsst_u', 'lsst_g', 'lsst_r', 
+            'lsst_i', 'lsst_z', 'lsst_y', 
+            'delta_lsst_u', 'delta_lsst_g', 
+            'delta_lsst_r', 'delta_lsst_i', 
+            'delta_lsst_z', 'delta_lsst_y', 
+            #'sigma_lsst_u','sigma_lsst_g','sigma_lsst_r',
+            #'sigma_lsst_i','sigma_lsst_z', 'sigma_lsst_y', 
+            'varParamStr']
 
-    def get_units(self):
-        return ['', 'rad', 'rad', 
-                '', '', '', '', '', '',
-                '', '', '', '', '', '', '' ]
+    column_outputs += ['diaSourceId', 'ccdVisitId', 'diaObjectId', 'ssObjectId',
+          'parentDiaSourceId', 'filterName', 'procHistoryId',
+          'ssObjectReassocTime', 'midPointTai', 'raSigma',
+          'declSigma', 'ra_decl_Cov', 'x', 'xSigma', 'y', 'ySigma', 
+          'x_y_Cov', 'snr', 'psFlux', 'psFluxSigma', 'psLnL', 'psChi2', 
+          'psN', 'trailFlux', 'trailFluxSigma', 'trailLength', 
+          'trailLengthSigma', 'trailAngle', 'trailAngleSigma', 
+          'trailFlux_trailLength_Cov', 'trailFlux_trailAngle_Cov', 
+          'trailLength_trailAngle_Cov', 'trailLnL', 'trailChi2', 'trailN', 
+          'fpFlux', 'fpFluxSigma', 'diffFlux', 'diffFluxSigma', 'fpSky', 
+          'fpSkySigma', 'E1', 'E1Sigma', 'E2', 'E2Sigma', 'E1_E2_Cov', 'mSum', 
+          'mSumSigma', 'extendedness', 'apMeanSb01', 'apMeanSb01Sigma', 
+          'apMeanSb02', 'apMeanSb02Sigma', 'apMeanSb03', 'apMeanSb03Sigma', 
+          'apMeanSb04', 'apMeanSb04Sigma', 'apMeanSb05', 'apMeanSb05Sigma', 
+          'apMeanSb06', 'apMeanSb06Sigma', 'apMeanSb07', 'apMeanSb07Sigma', 
+          'apMeanSb08', 'apMeanSb08Sigma', 'apMeanSb09', 'apMeanSb09Sigma', 
+          'apMeanSb10', 'apMeanSb10Sigma', 'flags', 'htmId20',]
+
+    default_columns = [('diaSourceId', rbi(), int), ('ccdVisitId', rbi(), int), 
+          ('diaObjectId', rbi(), int), ('ssObjectId', rbi(), int), 
+          ('parentDiaSourceId', rbi(), int), ('filterName', 0, (str,1)), 
+          ('procHistoryId', rbi(), int), ('ssObjectReassocTime', ri(), str), 
+	      ('midPointTai', rf(), float), ('raSigma', rf(), float), ('declSigma', rf(), float), 
+          ('ra_decl_Cov', rf(), float), ('x', rf(), float), ('xSigma', rf(), float), 
+          ('y', rf(), float), ('ySigma', rf(), float), ('x_y_Cov', rf(), float), 
+          ('snr', rf(), float), ('psFlux', rf(), float), ('psFluxSigma', rf(), float), 
+          ('psLnL', rf(), float), ('psChi2', rf(), float), ('psN', ri(), int), 
+          ('trailFlux', rf(), float), ('trailFluxSigma', rf(), float), 
+          ('trailLength', rf(), float), ('trailLengthSigma', rf(), float), 
+          ('trailAngle', rf(), float), ('trailAngleSigma', rf(), float), 
+          ('trailFlux_trailLength_Cov', rf(), float), 
+          ('trailFlux_trailAngle_Cov', rf(), float), 
+          ('trailLength_trailAngle_Cov', rf(), float), ('trailLnL', rf(), float), 
+          ('trailChi2', rf(), float), ('trailN', ri(), int), ('fpFlux', rf(), float), 
+          ('fpFluxSigma', rf(), float), ('diffFlux', rf(), float), 
+          ('diffFluxSigma', rf(), float), ('fpSky', rf(), float), 
+          ('fpSkySigma', rf(), float), ('E1', rf(), float), ('E1Sigma', rf(), float), 
+          ('E2', rf(), float), ('E2Sigma', rf(), float), ('E1_E2_Cov', rf(), float), 
+          ('mSum', rf(), float), ('mSumSigma', rf(), float), 
+          ('extendedness', rf(), float), 
+          ('apMeanSb01', rf(), float), ('apMeanSb01Sigma', rf(), float), 
+          ('apMeanSb02', rf(), float), ('apMeanSb02Sigma', rf(), float), 
+          ('apMeanSb03', rf(), float), ('apMeanSb03Sigma', rf(), float), 
+          ('apMeanSb04', rf(), float), ('apMeanSb04Sigma', rf(), float), 
+          ('apMeanSb05', rf(), float), ('apMeanSb05Sigma', rf(), float), 
+          ('apMeanSb06', rf(), float), ('apMeanSb06Sigma', rf(), float), 
+          ('apMeanSb07', rf(), float), ('apMeanSb07Sigma', rf(), float), 
+          ('apMeanSb08', rf(), float), ('apMeanSb08Sigma', rf(), float), 
+          ('apMeanSb09', rf(), float), ('apMeanSb09Sigma', rf(), float), 
+          ('apMeanSb10', rf(), float), ('apMeanSb10Sigma', rf(), float), 
+          ('flags', rbi(), int), ('htmId20', rbi(), int),]
+
+    def get_diaSourceId(self):
+        return self.column_by_name('simobjid')
+    
+    def get_htmId20(self):
+	    #return self.column_by_name('htmid')
+	    return self.column_by_name('htmID')
+
+    @staticmethod
+    def get_column_outputs(bandname):
+        return ['id', 'raJ2000', 'decJ2000','lsst_'+bandname,
+                'delta_lsst_'+bandname, 'sigma_lsst_'+bandname, 'varParamStr']
+
+    @staticmethod
+    def get_ucds():
+        return ['meta.id', 'pos.eq.ra', 'pos.eq.dec', 
+                'phot.mag', 'phot.mag', 
+                'phot.mag', 'phot.mag', 
+                'phot.mag', 'phot.mag', 
+                'phot.mag', 'phot.mag', 
+                'phot.mag', 'phot.mag', 
+                'phot.mag', 'phot.mag', 
+                #'stat.error', 'stat.error', 
+                #'stat.error', 'stat.error', 
+                #'stat.error', 'stat.error', 
+                'src.var',
+                'meta.id;obs.image', 'meta.id;obs.image', 'meta.id;src', 
+                'meta.id;src', 'meta.id;src', 'meta.id;instr.filter', '', '', 
+                'time.epoch', 'stat.error;pos.eq.ra', 
+                'stat.error;pos.eq.dec', '', 'pos.cartesian.x', 
+                'stat.error;pos.cartesian.x', 'pos.cartesian.y', 
+                'stat.error;pos.cartesian.y', '', '', 'phot.count', '', '', 
+                '', '', '', '', '', '', '', '', '', '', '', '', '', '',
+                'phot.count','stat.error;phot.count', '', 
+                'stat.error;phot.count', '', '', 'phys.size.axisRatio', 
+                'stat.error;phys.size.axisRatio', 'phys.size.axisRatio', 
+                'stat.error;phys.size.axisRatio', '', '', '', '', '', '', '', 
+                '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 
+                '', '', 'meta.code',]
+
+
+    @staticmethod
+    def get_units():
+        return ['', 'rad', 'rad', '', '', '', 
+                '', '', '', '', '', '', 
+                #'', '', '', '', '', '', 
+                '', '', '', '', 
+                '','','','','','','','','d','deg','deg','deg^2','pixel',
+                'pixel','pixel','pixel','pixel^2','','nmgy','nmgy','','','','nmgy',
+                'nmgy','arcsec','nmgy','degrees','nmgy','','','','','','','nmgy',
+                'nmgy','nmgy','nmgy','nmgy/asec^2','nmgy/asec^2','','','','','','',
+                '','','','','','','','','','','','','','','','','','','','','','','']
+
+class VariabilityDummy(Variability):
+    """ Dummy class for avoiding InstanceCatalog inheritance """
+    # include obs_metadata getter/setter in VariabilityMixin ?
+    def __init__(self, obs_metadata):
+        self.obs_metadata = obs_metadata
 
 class VanillaStars(InstanceCatalog):
     catalog_type = 'vanilla_stars'
     column_outputs = ['ra', 'decl', 'rmag']
 
-    def get_ucds(self):
+    @staticmethod
+    def get_ucds():
         return ['pos.eq.ra', 'pos.eq.dec', 'phot.mag']
 
-    def get_units(self):
+    @staticmethod
+    def get_units():
         return ['rad', 'rad', '']
 
 class DIASources(InstanceCatalog):
@@ -81,7 +178,7 @@ class DIASources(InstanceCatalog):
           ('diaObjectId', rbi(), int), ('ssObjectId', rbi(), int), 
           ('parentDiaSourceId', rbi(), int), ('filterName', 0, (str,1)), 
           ('procHistoryId', rbi(), int), ('ssObjectReassocTime', ri(), str), 
-	  ('midPointTai', rf(), float), ('ra', rf(), float), ('raSigma', rf(), float), 
+	      ('midPointTai', rf(), float), ('ra', rf(), float), ('raSigma', rf(), float), 
           ('decl', rf(), float), ('declSigma', rf(), float), 
           ('ra_decl_Cov', rf(), float), ('x', rf(), float), ('xSigma', rf(), float), 
           ('y', rf(), float), ('ySigma', rf(), float), ('x_y_Cov', rf(), float), 
@@ -117,9 +214,11 @@ class DIASources(InstanceCatalog):
         return self.column_by_name('simobjid')
     
     def get_htmId20(self):
-	    return self.column_by_name('htmID')
+	    return self.column_by_name('htmid')
+	    #return self.column_by_name('htmID')
   
-    def get_ucds(self):
+    @staticmethod
+    def get_ucds():
         return ['meta.id;obs.image', 'meta.id;obs.image', 'meta.id;src', 
                 'meta.id;src', 'meta.id;src', 'meta.id;instr.filter', '', '', 
                 'time.epoch', 'pos.eq.ra', 'stat.error;pos.eq.ra', 
@@ -134,14 +233,16 @@ class DIASources(InstanceCatalog):
                 '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 
                 '', '', 'meta.code', 'src.var']
   
-    def get_units(self):
+    @staticmethod
+    def get_units():
         return ['','','','','','','','','d','deg','deg','deg','deg','deg^2','pixel',
             'pixel','pixel','pixel','pixel^2','','nmgy','nmgy','','','','nmgy',
             'nmgy','arcsec','nmgy','degrees','nmgy','','','','','','','nmgy',
             'nmgy','nmgy','nmgy','nmgy/asec^2','nmgy/asec^2','','','','','','',
             '','','','','','','','','','','','','','','','','','','','','','','','']
   
-    def get_datatypes(self):
+    @staticmethod
+    def get_datatypes():
         return ['BIGINT','BIGINT','BIGINT','BIGINT','BIGINT','CHAR(1)','BIGINT',
             'DATETIME','DOUBLE','DOUBLE','FLOAT','DOUBLE','FLOAT','FLOAT','FLOAT',
             'FLOAT','FLOAT','FLOAT','FLOAT','FLOAT','FLOAT','FLOAT','FLOAT',
@@ -152,7 +253,8 @@ class DIASources(InstanceCatalog):
             'FLOAT','FLOAT','FLOAT','FLOAT','FLOAT','FLOAT','FLOAT','FLOAT',
             'FLOAT','FLOAT','FLOAT','FLOAT','FLOAT','FLOAT','BIGINT','BIGINT','STRING']
   
-    def get_descriptions(self):
+    @staticmethod
+    def get_descriptions():
         return ['Unique id.', 
                 'Id of the ccdVisit where this diaSource was measured. Note that we are allowing a diaSource to belong to multiple amplifiers, but it may not span multiple ccds.',
             'Id of the diaObject this source was associated with, if any. If not, it is set to NULL (each diaSource will be associated with either a diaObject or ssObject).',
@@ -228,7 +330,7 @@ class DIAObjects(InstanceCatalog):
 		      'nearbyObj3Dist','nearbyObj3LnP','flags','htmId20']
     default_columns = [('diaObjectId', rbi(), int), ('procHistoryId', rbi(), int), 
                        ('validityStart', 0, str), ('validityEnd', 0, str), 
-                       ('ra', 0, float), ('raSigma', rf(), float), ('decl', 0, float), 
+                       ('ra', rf(), float), ('raSigma', rf(), float), ('decl', rf(), float), 
                        ('declSigma', rf(), float), ('ra_decl_Cov', rf(), float), 
                        ('muRa', rf(), float), ('muRaSigma', rf(), float), 
                        ('muDecl', rf(), float), ('muDecSigma', rf(), float), 
@@ -275,7 +377,8 @@ class DIAObjects(InstanceCatalog):
     def get_muDecl(self):
         return self.column_by_name('mudecl')
     
-    def get_ucds(self):
+    @staticmethod
+    def get_ucds():
         return ['meta.id;src','','','','pos.eq.ra','stat.error;pos.eq.ra','pos.eq.dec',
                 'stat.error;pos.eq.dec','','pos.pm','stat.error;pos.pm','pos.pm',
                 'stat.error;pos.pm','stat.covariance;pos.eq','pos.parallax',
@@ -287,7 +390,8 @@ class DIAObjects(InstanceCatalog):
                 '','','','meta.id;src','','','meta.id;src','','','meta.id;src','','',
                 'meta.code']
   
-    def get_units(self):
+    @staticmethod
+    def get_units():
         return ['','','','','deg','deg','deg','deg','deg^2','mas/yr','mas/yr',
                 'mas/yr','mas/yr','(mas/yr)^2','mas','mas','','','','','',
                 'nmgy','nmgy','nmgy','nmgy','nmgy','nmgy','nmgy','nmgy','nmgy',
@@ -297,7 +401,8 @@ class DIAObjects(InstanceCatalog):
                 '','','','','','','','','','','','','','arcsec','','','arcsec',
                 '','','arcsec','','']
   
-    def get_datatypes(self):
+    @staticmethod
+    def get_datatypes():
         return ['BIGINT','BIGINT','DATETIME','DATETIME','DOUBLE','FLOAT','DOUBLE',
                 'FLOAT','FLOAT','FLOAT','FLOAT','FLOAT','FLOAT','FLOAT','FLOAT',
                 'FLOAT','FLOAT','FLOAT','FLOAT','FLOAT','INT','FLOAT','FLOAT',
@@ -309,7 +414,8 @@ class DIAObjects(InstanceCatalog):
                 'BLOB','BLOB','BLOB','BLOB','BLOB','BIGINT','FLOAT','FLOAT',
                 'BIGINT','FLOAT','FLOAT','BIGINT','FLOAT','FLOAT','BIGINT','BIGINT']
   
-    def get_descriptions(self):
+    @staticmethod
+    def get_descriptions():
         return ['Unique id.',
                 'Pointer to ProcessingHistory table.',
                 'Time when validity of this diaObject starts.',
@@ -374,3 +480,4 @@ class DIAObjects(InstanceCatalog):
                 'Id of the third-closest nearby object.','Distance to nearbyObj3.',
                 'Natural log of the probability that the observed diaObject is the same as the nearbyObj3.',
                 'Flags, bitwise OR tbd.','HTM index.']
+


### PR DESCRIPTION
- ObservationMetaData objects are now formed immediately in opsim_utils (SIM-1984)
- For each event, historical data of the same object is included. Only one trip to DB per visit is made (historical data is calculated in local). Lightcurves are calculated via VariabilityMixins' applyVariability.
- Added exception for IndexError when list is out of bounds in case of zero events in a visit
- Added a method for handling nested objects via settattr
- Added program parameter --no_history if only current event is sent in diasource (SIM-1985)
- Removed -cc parameter for selecting a catalog
- Lots of minor changes / code polishing / comments
